### PR TITLE
Artifact Publishing & Subscription Topic Bug Fix

### DIFF
--- a/.github/workflows/artifact-publish.yml
+++ b/.github/workflows/artifact-publish.yml
@@ -1,0 +1,31 @@
+name: Publish Java Package
+
+on:
+  push:
+    tags:
+      - 'jpo-sdw-depositor-*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'adopt'
+
+    - name: Remove snapshot from version
+      run: mvn versions:set -DremoveSnapshot
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to GitHub Packages
+      run: mvn --batch-mode -Dgithub_organization=${{ github.repository_owner }} deploy
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN mvn clean package -DskipTests
 FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /home
-COPY --from=builder /home/target/jpo-sdw-depositor-1.7.0-SNAPSHOT.jar /home
+COPY --from=builder /home/target/jpo-sdw-depositor-1.8.0-SNAPSHOT.jar /home
 
 ENTRYPOINT ["java", \
 	"-jar", \
-	"/home/jpo-sdw-depositor-1.7.0-SNAPSHOT.jar"]
+	"/home/jpo-sdw-depositor-1.8.0-SNAPSHOT.jar"]

--- a/README.md
+++ b/README.md
@@ -114,3 +114,61 @@ There is a provided docker-compose file (docker-compose-confluent-cloud.yml) tha
 
 ### Note
 This has only been tested with Confluent Cloud but technically all SASL authenticated Kafka brokers can be reached using this method.
+
+## GitHub Artifact Usage
+
+To use this library in another application, add the GitHub package URLs to the `repositories` section in `pom.xml` of the consumer application or in your local `~/.m2/settings.xml` file. Here is an example implementation of using the GitHub artifact in a consumer application:
+
+```xml
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <activeProfiles>
+    <activeProfile>github</activeProfile>
+  </activeProfiles>
+
+  <profiles>
+    <profile>
+      <id>github</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+          <id>github</id>
+          <url>https://maven.pkg.github.com/usdot-jpo-ode/jpo-sdw-depositor</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <servers>
+    <server>
+      <id>github</id>
+      <username>${env.PACKAGE_READ_USERNAME}</username>
+      <password>${env.PACKAGE_READ_TOKEN}</password>
+    </server>
+  </servers>
+
+</settings>
+```
+
+And add the following line to the `dependencies` element in `build.gradle`
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>usdot.jpo.ode</groupId>
+    <artifactId>jpo-sdw-depositor</artifactId>
+    <version>1.0.0</version>
+  </dependency>
+</dependencies>
+```
+
+Finally, set the environment variables:
+
+* PACKAGE_READ_USERNAME - User name with read access to the repositories containing the packages.
+* PACKAGE_READ_TOKEN - Personal access token with `read:packages` scope.

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,6 +1,16 @@
 jpo-sdw-depositor Release Notes
 ----------------------------
 
+Version 1.8.0, released September 2024
+----------------------------------------
+### **Summary**
+The changes for the jpo-sdw-depositor 1.8.0 release include a fix for the SDW_SUBSCRIPTION_TOPIC environment variable not getting used instead of the default if provided, as well as the addition of a GitHub action to publish Java artifacts to GitHub's hosted Maven Central.
+
+Enhancements in this release:
+- CDOT PR 24: Fixed SDW_SUBSCRIPTION_TOPIC environment variable not getting used instead of default if provided
+- CDOT PR 25: Added a GiHub action to opublish java artifacts to GitHub's hosted Maven Central
+
+
 Version 1.7.0, released June 2024
 ----------------------------------------
 ### **Summary**

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,9 @@
                   <loader.path>${loader.path}</loader.path>
                   <buildDirectory>${project.build.directory}</buildDirectory>
                </systemPropertyVariables>
+               <environmentVariables>
+                  <SDW_SUBSCRIPTION_TOPIC>testSubscriptionTopic</SDW_SUBSCRIPTION_TOPIC>
+                </environmentVariables>
             </configuration>
             <dependencies>
                <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
    </parent>
    <groupId>usdot.jpo.ode</groupId>
    <artifactId>jpo-sdw-depositor</artifactId>
-   <version>1.7.0-SNAPSHOT</version>
+   <version>1.8.0-SNAPSHOT</version>
    <packaging>jar</packaging>
    <name>jpo-sdw-depositor</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
       <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
       <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
       <sonar.language>java</sonar.language>
+      <github_organization>usdot-jpo-ode</github_organization>
    </properties>
 
    <dependencies>
@@ -142,4 +143,11 @@
          </plugin>
       </plugins>
    </build>
+   <distributionManagement>
+      <repository>
+         <id>github</id>
+         <name>GitHub Packages</name>
+         <url>https://maven.pkg.github.com/${github_organization}/jpo-sdw-depositor</url>
+      </repository>
+   </distributionManagement>
 </project>

--- a/src/main/java/jpo/sdw/depositor/DepositorProperties.java
+++ b/src/main/java/jpo/sdw/depositor/DepositorProperties.java
@@ -2,8 +2,6 @@ package jpo.sdw.depositor;
 
 import java.util.regex.Pattern;
 
-import jakarta.annotation.PostConstruct;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,6 +9,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
+
+import jakarta.annotation.PostConstruct;
 
 @ConfigurationProperties("sdw")
 @PropertySource("classpath:application.properties")
@@ -66,9 +66,15 @@ public class DepositorProperties implements EnvironmentAware {
       }
 
       if (getSubscriptionTopics() == null || getSubscriptionTopics().length == 0) {
-         String topics = String.join(",", DEFAULT_SUBSCRIPTION_TOPICS);
-         logger.info("No Kafka subscription topics specified in configuration, defaulting to {}", topics);
-         subscriptionTopics = DEFAULT_SUBSCRIPTION_TOPICS;
+         // get environment variable SDW_SUBSCRIPTION_TOPIC
+         String topics = System.getenv("SDW_SUBSCRIPTION_TOPIC");
+         if (topics == null || topics.isEmpty()) {
+            topics = String.join(",", DEFAULT_SUBSCRIPTION_TOPICS);
+            logger.info("No Kafka subscription topics specified in configuration, defaulting to {}", topics);
+            subscriptionTopics = DEFAULT_SUBSCRIPTION_TOPICS;
+         } else {
+            subscriptionTopics = topics.split(",");
+         }
       }
 
       if (getApiKey() == null || getApiKey().isEmpty()) {


### PR DESCRIPTION
## Artifact Publishing
This update adds a GitHub Action to publish Java artifacts to GitHub's hosted Maven Central repository.

## Subscription Topic Bug Fix
This fix modifies the SDW-depositor to use the SDW_SUBSCRIPTION_TOPIC environment variable if it's set, instead of the default value. The changes were tested locally with Docker, and all existing unit tests were verified to pass successfully.