### PR TITLE
Automate Dockerfile Version Handling and Apply Linter Suggestions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,19 +3,15 @@
 {
 	"name": "Java",
 	"build": {
-		"dockerfile": "Dockerfile",
+		"dockerfile": "Dockerfile"
 	},
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
-		"java.home": "/docker-java-home"
+	"customizations": {
+		"extensions": [
+			"vscjava.vscode-java-pack"
+		]
 	},
-	
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"vscjava.vscode-java-pack"
-	],
-
 
 	"containerEnv": {
 		"SHELL": "/bin/bash"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM eclipse-temurin:21-jre-alpine
 WORKDIR /home
 # Copy the jar file from the builder image to the new image 
 # since we run mvn clean package, there should only be one jar file in the target directory, and we can safely copy it with a wildcard
-COPY --from=builder /home/target/jpo-sdw-depositor-*-SNAPSHOT.jar /home/jpo-sdw-depositor.jar
+COPY --from=builder /home/target/jpo-sdw-depositor-*.jar /home/jpo-sdw-depositor.jar
 
 ENTRYPOINT ["java", \
 	"-jar", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build container
-FROM maven:3.8-eclipse-temurin-21-alpine as builder
-MAINTAINER 583114@bah.com
+FROM maven:3.8-eclipse-temurin-21-alpine AS builder
+LABEL maintainer="583114@bah.com"
 
 WORKDIR /home
 
@@ -14,8 +14,10 @@ RUN mvn clean package -DskipTests
 FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /home
-COPY --from=builder /home/target/jpo-sdw-depositor-1.8.0-SNAPSHOT.jar /home
+# Copy the jar file from the builder image to the new image 
+# since we run mvn clean package, there should only be one jar file in the target directory, and we can safely copy it with a wildcard
+COPY --from=builder /home/target/jpo-sdw-depositor-*-SNAPSHOT.jar /home/jpo-sdw-depositor.jar
 
 ENTRYPOINT ["java", \
 	"-jar", \
-	"/home/jpo-sdw-depositor-1.8.0-SNAPSHOT.jar"]
+	"/home/jpo-sdw-depositor.jar"]

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -14,6 +14,7 @@ linter recommendations. These changes enhance reliability and maintainability wh
 
 Enhancements in this release:
 - [CDOT PR 28](https://github.com/CDOT-CV/jpo-sdw-depositor/pull/28): Dockerfile jar rename
+- [CDOT PR 30](https://github.com/CDOT-CV/jpo-sdw-depositor/pull/30): Fixed Dockerfile to correctly copy JAR after version update (SNAPSHOT removal)
 
 Known issues:
 - No known issues at this time.

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,6 +1,18 @@
 jpo-sdw-depositor Release Notes
 ----------------------------
 
+Version 1.9.0, released January 2025
+----------------------------------------
+### **Summary**
+The jpo-sdw-depositor 1.9.0 release simplifies and improves the Docker build process by automating the handling of versioned jar files, eliminating the need for manual updates to the Dockerfile with each new version. The Dockerfile now ensures versioned jars are copied to an unversioned name within the Docker image, allowing the application to reference a static file name while preserving versioned jars for distribution. Additionally, polish updates were made to modernize and streamline the build process, including replacing the deprecated MAINTAINER field with LABEL maintainer, resolving casing inconsistencies in Docker commands, and cleaning up unnecessary configurations in .devcontainer.json based on linter recommendations. These changes enhance reliability and maintainability while reducing the risk of errors.
+
+Enhancements in this release:
+- [CDOT PR 28](https://github.com/CDOT-CV/jpo-sdw-depositor/pull/28): Dockerfile jar rename
+
+Known issues:
+- No known issues at this time.
+
+
 Version 1.8.0, released September 2024
 ----------------------------------------
 ### **Summary**
@@ -8,7 +20,7 @@ The changes for the jpo-sdw-depositor 1.8.0 release include a fix for the SDW_SU
 
 Enhancements in this release:
 - CDOT PR 24: Fixed SDW_SUBSCRIPTION_TOPIC environment variable not getting used instead of default if provided
-- CDOT PR 25: Added a GiHub action to opublish java artifacts to GitHub's hosted Maven Central
+- CDOT PR 25: Added a GitHub action to publish java artifacts to GitHub's hosted Maven Central
 
 
 Version 1.7.0, released June 2024

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -4,7 +4,13 @@ jpo-sdw-depositor Release Notes
 Version 1.9.0, released January 2025
 ----------------------------------------
 ### **Summary**
-The jpo-sdw-depositor 1.9.0 release simplifies and improves the Docker build process by automating the handling of versioned jar files, eliminating the need for manual updates to the Dockerfile with each new version. The Dockerfile now ensures versioned jars are copied to an unversioned name within the Docker image, allowing the application to reference a static file name while preserving versioned jars for distribution. Additionally, polish updates were made to modernize and streamline the build process, including replacing the deprecated MAINTAINER field with LABEL maintainer, resolving casing inconsistencies in Docker commands, and cleaning up unnecessary configurations in .devcontainer.json based on linter recommendations. These changes enhance reliability and maintainability while reducing the risk of errors.
+The jpo-sdw-depositor 1.9.0 release simplifies and improves the Docker build process by automating the handling of 
+versioned jar files, eliminating the need for manual updates to the Dockerfile with each new version. The Dockerfile now
+ensures versioned jars are copied to an unversioned name within the Docker image, allowing the application to reference 
+a static file name while preserving versioned jars for distribution. Additionally, polish updates were made to modernize 
+and streamline the build process, including replacing the deprecated MAINTAINER field with LABEL maintainer, resolving 
+casing inconsistencies in Docker commands, and cleaning up unnecessary configurations in .devcontainer.json based on 
+linter recommendations. These changes enhance reliability and maintainability while reducing the risk of errors.
 
 Enhancements in this release:
 - [CDOT PR 28](https://github.com/CDOT-CV/jpo-sdw-depositor/pull/28): Dockerfile jar rename

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
    </parent>
    <groupId>usdot.jpo.ode</groupId>
    <artifactId>jpo-sdw-depositor</artifactId>
-   <version>1.8.0-SNAPSHOT</version>
+   <version>1.9.0</version>
    <packaging>jar</packaging>
    <name>jpo-sdw-depositor</name>
 


### PR DESCRIPTION
## Problem  
Each time the version is updated in the [pom.xml](https://github.com/CDOT-CV/jpo-sdw-depositor/blob/058cb39da5ccd346c4e88790cdc33b9a9dea7bb8/pom.xml#L16), the Dockerfile must be updated to reference the new version. This process is tedious, error-prone (due to reliance on human intervention), and could be automated.

## Solution  
The Dockerfile was updated to copy the _versioned_ JAR file produced by Spring Boot's `repackage` Maven target (executed when `mvn package` is called on Line 11 in the Dockerfile) to an _unversioned_ JAR file on the Docker image. This update ensures that versioned JAR files can still be produced for packaging and distribution, while allowing the JAR file to be referenced by a static name in the resulting Docker image.

## Testing  
`docker compose up --build` was executed locally, and the container and its logs were inspected to confirm that the JAR file was copied correctly and the application ran as expected. Additionally, `./run.sh` was used to run the application locally. However, since no connection to Confluent Cloud was available, functionality beyond the application startup and error logs related to the CC connection could not be confirmed.

## Notes/Additional Changes  
- **Polish**: The change from `MAINTAINER` to `LABEL` in the Dockerfile was suggested by the Docker plugin in VSCode, as `MAINTAINER` is a deprecated field replaced by `LABEL maintainer`.  
- **Polish**: The change from lowercase `as` to uppercase `AS` in the Dockerfile was implemented to address a Docker build warning about inconsistent casing.  
- **Polish**: Changes to `.devcontainer.json` were provided by the VSCode linter and editor. The `java.home` configuration was deemed unnecessary because the base [OpenJDK](https://hub.docker.com/r/cimg/openjdk/) image configures the home directory in a standard manner that VSCode can automatically detect.  
